### PR TITLE
update text upper-bound

### DIFF
--- a/zenacy-html.cabal
+++ b/zenacy-html.cabal
@@ -69,7 +69,7 @@ library
     pretty-show       >= 1.6 && < 1.11,
     safe              >= 0.3.14 && < 0.4,
     safe-exceptions   >= 0.1.5.0 && < 0.2,
-    text              >= 1.2.2.0 && < 2.1,
+    text              >= 1.2.2.0 && < 2.2,
     transformers      >= 0.5.2 && < 0.7,
     vector            >= 0.11 && < 0.14,
     word8             >= 0.1.2 && < 0.2


### PR DESCRIPTION
This package conflicts with `base 4.20.0.0`, used by `ghci 9.10.1`. It seems that increasing the upper bound of text would solve this.

Using `cabal 3.10.3.0` and `ghci 9.10.1`:

```
Error: cabal: Could not resolve dependencies:
[__0] trying: haskell-mailer-0.1.0.0 (user goal)
[__1] trying: zenacy-html-2.1.0 (dependency of my-proj)
[__2] next goal: text (dependency of my-proj)
[__2] rejecting: text-2.1.1/installed-05f2 (conflict: zenacy-html =>
text>=1.2.2.0 && <2.1)
[__2] skipping: text-2.1.1, text-2.1 (has the same characteristics that caused
the previous version to fail: excluded by constraint '>=1.2.2.0 && <2.1' from
'zenacy-html')
```